### PR TITLE
Added MANIFEST.in to project directory

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,14 @@
+# Include all files (this is a catch-all, but can be refined if needed)
+include *
+
+# Include all directories and their content recursively
+graft src
+
+# Include README and requirements
+include README.md
+include requirements.txt
+
+# Exclude all bytecode files
+global-exclude *.pyc
+global-exclude *.pyo
+global-exclude __pycache__/


### PR DESCRIPTION
Added MANIFEST.in to project directory to ensure that that all the Python modules and packages inside the src directory (like data_extraction, data_preparation, ml, etc.) are included when you create a source distribution