### PR TITLE
Removed version number from PyYAML in requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -472,7 +472,8 @@ pywinpty==2.0.11
     #   jupyter-server
     #   jupyter-server-terminals
     #   terminado
-pyyaml==5.4.1
+#pyyaml==5.4.1
+pyyaml
     # via
     #   auto-ts
     #   dask


### PR DESCRIPTION
Removed version number from PyYAML in requirements.txt to resolve issue on 'Install dependencies' in Github Actions.